### PR TITLE
[Fix] 포트 포워딩 갯수가 많아지면 서버가 터지던 문제 수정

### DIFF
--- a/.github/workflows/back-media-cd.yml
+++ b/.github/workflows/back-media-cd.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: 🐳 media 컨테이너 실행
         run: |
-          docker run -dit --name media -p 3002:3002 -p 30000-30500:30000-30500/tcp -p 30000-30500:30000-30500/udp ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
+          docker run -dit --network host --name media ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
 
       - name: 🐳 사용하지 않는 Docker 이미지 제거
         run: |

--- a/apps/media/src/main.ts
+++ b/apps/media/src/main.ts
@@ -8,7 +8,6 @@ async function bootstrap() {
 
   const configService = app.get(ConfigService);
   const port = configService.get<number>('MEDIA_SERVER_PORT') ?? 8080;
-
-  await app.listen(port);
+  await app.listen(port, '0.0.0.0');
 }
 bootstrap();


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #3 

## 작업 내용
- media server cd부분 변경하여 도커 컨테이너가 호스트모드로 동작하게 변경했습니다.
- 127.0.0.1은 컨테이너 내부의 네트워크환경에만 해당하여 외부접속이 불가능하다고 합니다 따라서 서버를 0.0.0.0으로 바인딩 합니다.

## PR 포인트
- mac 환경에서는 host모드가 정상작동 하지 않는다고 하여 테스트를 진행못했습니다...
- 기술 공유 후 배포하면서 테스트 진행해보겠습니다.

## 고민과 학습내용
- 문제해결을 위해 학습한 내용들을 노션에 상세히 정리해놓았습니다.
- [notion 정리글](https://simeunseo.notion.site/4-260728e396a841718749ad2e6ab026e2)

## 스크린샷
