### PR TITLE
[Fix] 티클 리스트 조회 쿼리 최적화 

### DIFF
--- a/.github/workflows/back-media-cd.yml
+++ b/.github/workflows/back-media-cd.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           docker run -dit --name media -p 3002:3002 -p 30000-30500:30000-30500/tcp -p 30000-30500:30000-30500/udp ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
 
-       - name: 🐳 Docker 상태 확인
+      - name: 🐳 Docker 상태 확인
         run: |
           sleep 10  # 컨테이너가 시작될 시간을 주기 위한 대기 시간
           docker ps -a

--- a/.github/workflows/back-media-cd.yml
+++ b/.github/workflows/back-media-cd.yml
@@ -2,7 +2,7 @@ name: 백엔드 @app/media CD
 
 on:
   push:
-    branches: [main, release]
+    branches: [main, release, feat/#1/media-build]
 
 jobs:
   ci:
@@ -59,13 +59,27 @@ jobs:
           username: ${{secrets.DOCKER_REGISTRY_ACCESS_KEY}}
           password: ${{secrets.DOCKER_REGISTRY_SECRET_KEY}}
 
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 🐳 Docker 빌드 및 푸시
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/media/Dockerfile
+          push: true
+          tags: ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }},${{secrets.DOCKER_REGISTRY_URL}}/media:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: 🐳 Docker 빌드 및 푸시
         run: docker buildx build -f apps/media/Dockerfile . -t ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }} -t ${{secrets.DOCKER_REGISTRY_URL}}/media:latest --push
 
-  deploy:
+  deploy-test:
     needs: build
     name: Deploy media
-    runs-on: [ticle-main]
+    runs-on: ubuntu-latest
 
     steps:
       - name: 🐳 Docker 로그인
@@ -79,15 +93,42 @@ jobs:
         run: |
           docker pull ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
 
-      - name: 🐳 Docker 기존 컨테이너 종료
-        run: |
-          docker stop media || true
-          docker rm media || true
-
       - name: 🐳 media 컨테이너 실행
         run: |
           docker run -dit --name media -p 3002:3002 -p 30000-30500:30000-30500/tcp -p 30000-30500:30000-30500/udp ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
 
-      - name: 🐳 사용하지 않는 Docker 이미지 제거
+       - name: 🐳 Docker 상태 확인
         run: |
-          docker image prune --all --force
+          sleep 10  # 컨테이너가 시작될 시간을 주기 위한 대기 시간
+          docker ps -a
+          docker logs media  # 로그 확인
+
+  # deploy:
+  #   needs: build
+  #   name: Deploy media
+  #   runs-on: [ticle-main]
+
+  #   steps:
+  #     - name: 🐳 Docker 로그인
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ${{secrets.DOCKER_REGISTRY_URL}}
+  #         username: ${{secrets.DOCKER_REGISTRY_ACCESS_KEY}}
+  #         password: ${{secrets.DOCKER_REGISTRY_SECRET_KEY}}
+
+  #     - name: 🐳 Docker 이미지 다운로드
+  #       run: |
+  #         docker pull ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
+
+  #     - name: 🐳 Docker 기존 컨테이너 종료
+  #       run: |
+  #         docker stop media || true
+  #         docker rm media || true
+
+  #     - name: 🐳 media 컨테이너 실행
+  #       run: |
+  #         docker run -dit --name media -p 3002:3002 -p 30000-30500:30000-30500/tcp -p 30000-30500:30000-30500/udp ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
+
+  #     - name: 🐳 사용하지 않는 Docker 이미지 제거
+  #       run: |
+  #         docker image prune --all --force

--- a/.github/workflows/back-media-cd.yml
+++ b/.github/workflows/back-media-cd.yml
@@ -71,7 +71,7 @@ jobs:
           push: true
           tags: ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }},${{secrets.DOCKER_REGISTRY_URL}}/media:latest
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
   deploy-test:
     needs: build
@@ -99,7 +99,6 @@ jobs:
           sleep 10  # 컨테이너가 시작될 시간을 주기 위한 대기 시간
           docker ps -a
           docker logs media  # 로그 확인
-          echo "캐싱 적용 확인"
 
   # deploy:
   #   needs: build

--- a/.github/workflows/back-media-cd.yml
+++ b/.github/workflows/back-media-cd.yml
@@ -73,9 +73,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: 🐳 Docker 빌드 및 푸시
-        run: docker buildx build -f apps/media/Dockerfile . -t ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }} -t ${{secrets.DOCKER_REGISTRY_URL}}/media:latest --push
-
   deploy-test:
     needs: build
     name: Deploy media

--- a/.github/workflows/back-media-cd.yml
+++ b/.github/workflows/back-media-cd.yml
@@ -99,6 +99,7 @@ jobs:
           sleep 10  # 컨테이너가 시작될 시간을 주기 위한 대기 시간
           docker ps -a
           docker logs media  # 로그 확인
+          echo "캐싱 적용 확인"
 
   # deploy:
   #   needs: build

--- a/.github/workflows/back-media-cd.yml
+++ b/.github/workflows/back-media-cd.yml
@@ -2,7 +2,7 @@ name: 백엔드 @app/media CD
 
 on:
   push:
-    branches: [main, release, feat/#1/media-build]
+    branches: [main, release]
 
 jobs:
   ci:
@@ -76,7 +76,7 @@ jobs:
   deploy-test:
     needs: build
     name: Deploy media
-    runs-on: ubuntu-latest
+    runs-on: [ticle-main]
 
     steps:
       - name: 🐳 Docker 로그인
@@ -90,42 +90,15 @@ jobs:
         run: |
           docker pull ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
 
+      - name: 🐳 Docker 기존 컨테이너 종료
+        run: |
+          docker stop media || true
+          docker rm media || true
+
       - name: 🐳 media 컨테이너 실행
         run: |
           docker run -dit --name media -p 3002:3002 -p 30000-30500:30000-30500/tcp -p 30000-30500:30000-30500/udp ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
 
-      - name: 🐳 Docker 상태 확인
+      - name: 🐳 사용하지 않는 Docker 이미지 제거
         run: |
-          sleep 10  # 컨테이너가 시작될 시간을 주기 위한 대기 시간
-          docker ps -a
-          docker logs media  # 로그 확인
-
-  # deploy:
-  #   needs: build
-  #   name: Deploy media
-  #   runs-on: [ticle-main]
-
-  #   steps:
-  #     - name: 🐳 Docker 로그인
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ${{secrets.DOCKER_REGISTRY_URL}}
-  #         username: ${{secrets.DOCKER_REGISTRY_ACCESS_KEY}}
-  #         password: ${{secrets.DOCKER_REGISTRY_SECRET_KEY}}
-
-  #     - name: 🐳 Docker 이미지 다운로드
-  #       run: |
-  #         docker pull ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
-
-  #     - name: 🐳 Docker 기존 컨테이너 종료
-  #       run: |
-  #         docker stop media || true
-  #         docker rm media || true
-
-  #     - name: 🐳 media 컨테이너 실행
-  #       run: |
-  #         docker run -dit --name media -p 3002:3002 -p 30000-30500:30000-30500/tcp -p 30000-30500:30000-30500/udp ${{secrets.DOCKER_REGISTRY_URL}}/media:${{ github.sha }}
-
-  #     - name: 🐳 사용하지 않는 Docker 이미지 제거
-  #       run: |
-  #         docker image prune --all --force
+          docker image prune --all --force

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,10 +19,12 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node src/seeds/seed.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.700.0",
+    "@faker-js/faker": "^9.3.0",
     "@nestjs/common": "^10.4.6",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
@@ -50,6 +52,7 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.20",
+    "typeorm-extension": "^3.6.3",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0",
     "zod": "^3.23.8"

--- a/apps/api/src/entity/ticle.entity.ts
+++ b/apps/api/src/entity/ticle.entity.ts
@@ -19,6 +19,7 @@ import { Tag } from './tag.entity';
 import { User } from './user.entity';
 
 @Entity('ticle')
+@Index('idx_id_created_at', ['id', 'created_at'])
 @Index('idx_fulltext_search', ['title', 'content'], { fulltext: true })
 export class Ticle {
   @PrimaryGeneratedColumn({ type: 'bigint' })
@@ -52,6 +53,7 @@ export class Ticle {
   @Column({ type: 'enum', enum: TicleStatus, default: TicleStatus.OPEN, name: 'ticle_status' })
   ticleStatus: TicleStatus;
 
+  @Index()
   @CreateDateColumn({ type: 'timestamp', name: 'created_at' })
   createdAt: Date;
 

--- a/apps/api/src/entity/ticle.entity.ts
+++ b/apps/api/src/entity/ticle.entity.ts
@@ -19,7 +19,7 @@ import { Tag } from './tag.entity';
 import { User } from './user.entity';
 
 @Entity('ticle')
-// @Index('idx_id_created_at', ['id', 'created_at'])
+@Index('idx_id_created_at', ['id', 'createdAt'])
 @Index('idx_fulltext_search', ['title', 'content'], { fulltext: true })
 export class Ticle {
   @PrimaryGeneratedColumn({ type: 'bigint' })

--- a/apps/api/src/entity/ticle.entity.ts
+++ b/apps/api/src/entity/ticle.entity.ts
@@ -19,7 +19,7 @@ import { Tag } from './tag.entity';
 import { User } from './user.entity';
 
 @Entity('ticle')
-@Index('idx_id_created_at', ['id', 'created_at'])
+// @Index('idx_id_created_at', ['id', 'created_at'])
 @Index('idx_fulltext_search', ['title', 'content'], { fulltext: true })
 export class Ticle {
   @PrimaryGeneratedColumn({ type: 'bigint' })

--- a/apps/api/src/seeds/applicant.seeder.ts
+++ b/apps/api/src/seeds/applicant.seeder.ts
@@ -1,0 +1,37 @@
+import { faker } from '@faker-js/faker';
+import { DataSource } from 'typeorm';
+
+import { Applicant } from '../entity/applicant.entity'; // Applicant 엔티티 경로 확인
+import { Ticle } from '../entity/ticle.entity'; // Ticle 엔티티 경로 확인
+import { User } from '../entity/user.entity'; // User 엔티티 경로 확인
+
+export const seedApplicants = async (dataSource: DataSource, count: number) => {
+  const applicantRepository = dataSource.getRepository(Applicant);
+  const ticleRepository = dataSource.getRepository(Ticle);
+  const userRepository = dataSource.getRepository(User);
+
+  const existingTicles = await ticleRepository.find();
+  const existingUsers = await userRepository.find();
+
+  for (let i = 0; i < count; i++) {
+    // 랜덤한 타이클과 사용자 선택
+    const randomTicle = faker.helpers.arrayElement(existingTicles);
+    const randomUser = faker.helpers.arrayElement(existingUsers);
+
+    const applicant = applicantRepository.create({
+      ticle: randomTicle,
+      user: randomUser,
+    });
+
+    try {
+      await applicantRepository.save(applicant);
+    } catch (error) {
+      console.error(
+        `Error seeding applicant for Ticle ID ${randomTicle.id} and User ID ${randomUser.id}:`,
+        error
+      );
+    }
+  }
+
+  console.log(`${count} applicants seeded!`);
+};

--- a/apps/api/src/seeds/datasource.ts
+++ b/apps/api/src/seeds/datasource.ts
@@ -1,0 +1,21 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+
+import { Applicant } from '../entity/applicant.entity';
+import { Summary } from '../entity/summary.entity';
+import { Tag } from '../entity/tag.entity';
+import { Ticle } from '../entity/ticle.entity';
+import { User } from '../entity/user.entity';
+
+// 데이터 소스 초기화
+export const AppDataSource = new DataSource({
+  type: 'mysql', // 사용할 데이터베이스 종류
+  host: 'localhost', // 데이터베이스 호스트
+  port: 3306, // 데이터베이스 포트
+  username: 'root', // 사용자 이름
+  password: '123', // 비밀번호
+  database: 'ticle_test', // 데이터베이스 이름
+  synchronize: true, // 개발 중에는 true로 설정 (생성된 엔티티에 따라 테이블을 동기화)
+  logging: true, // 쿼리 로깅
+  entities: [User, Ticle, Tag, Applicant, Summary], // 사용할 엔티티 목록
+});

--- a/apps/api/src/seeds/seed.ts
+++ b/apps/api/src/seeds/seed.ts
@@ -1,0 +1,27 @@
+import { seedApplicants } from './applicant.seeder';
+import { AppDataSource } from './datasource';
+import { seedTags } from './tag.seeder';
+import { seedTicles } from './ticle.seeder';
+import { seedUsers } from './user.seeder';
+
+const seedDatabase = async () => {
+  try {
+    // 데이터 소스 초기화
+    await AppDataSource.initialize();
+    console.log('Database connected successfully!');
+
+    // User 데이터를 Seed
+    // await seedUsers(AppDataSource, 1000);
+    // await seedTicles(AppDataSource, 3_000_000);
+    // await seedTags(AppDataSource, 100);
+    // await seedApplicants(AppDataSource, 1000);
+
+    console.log('Seeding completed!');
+    process.exit(0);
+  } catch (error) {
+    console.error('Error seeding database:', error);
+    process.exit(1);
+  }
+};
+
+seedDatabase();

--- a/apps/api/src/seeds/tag.seeder.ts
+++ b/apps/api/src/seeds/tag.seeder.ts
@@ -1,0 +1,43 @@
+import { faker } from '@faker-js/faker';
+import { DataSource } from 'typeorm';
+
+import { Tag } from '../entity/tag.entity'; // Tag 엔티티 경로 확인
+import { Ticle } from '../entity/ticle.entity'; // Ticle 엔티티 경로 확인
+
+export const seedTags = async (dataSource: DataSource, count: number) => {
+  const tagRepository = dataSource.getRepository(Tag);
+  const ticleRepository = dataSource.getRepository(Ticle);
+
+  // 기존 태그와 타이클을 가져옵니다.
+  const existingTags = await tagRepository.find();
+  const existingTagNames = new Set(existingTags.map((tag) => tag.name));
+  const existingTicles = await ticleRepository.find();
+
+  for (let i = 0; i < count; i++) {
+    let name;
+    do {
+      name = faker.word.adjective(); // 랜덤한 단어 생성
+    } while (existingTagNames.has(name)); // 중복 확인
+
+    const tag = tagRepository.create({
+      name,
+    });
+
+    // 태그 저장
+    await tagRepository.save(tag);
+    existingTagNames.add(name); // 새로 생성된 태그 이름 추가
+
+    // 랜덤하게 타이클을 선택하고 연결합니다.
+    if (existingTicles.length > 0) {
+      const randomTicle = faker.helpers.arrayElement(existingTicles);
+      // 이미 태그가 있으면 추가하고, 없으면 새로 만들어서 연결
+      if (!randomTicle.tags) {
+        randomTicle.tags = [];
+      }
+      randomTicle.tags.push(tag);
+      await ticleRepository.save(randomTicle); // 수정된 타이클 저장
+    }
+  }
+
+  console.log(`${count} tags seeded!`);
+};

--- a/apps/api/src/seeds/ticle.seeder.ts
+++ b/apps/api/src/seeds/ticle.seeder.ts
@@ -1,0 +1,36 @@
+import { faker } from '@faker-js/faker';
+import { DataSource } from 'typeorm';
+import { TicleStatus } from '@repo/types'; // TicleStatus enum 경로 확인
+
+import { Ticle } from '../entity/ticle.entity';
+import { User } from '../entity/user.entity';
+
+export const seedTicles = async (dataSource: DataSource, count: number) => {
+  const ticleRepository = dataSource.getRepository(Ticle);
+  const userRepository = dataSource.getRepository(User);
+
+  // 사용자 목록을 가져옵니다.
+  const users = await userRepository.find();
+
+  for (let i = 0; i < count; i++) {
+    // 임의의 사용자 선택
+    const randomUser = users[Math.floor(Math.random() * users.length)];
+
+    const ticle = ticleRepository.create({
+      speaker: randomUser,
+      speakerName: randomUser.nickname, // 사용자 이름 사용
+      speakerEmail: randomUser.email, // 사용자 이메일 사용
+      speakerIntroduce: faker.lorem.sentence(),
+      title: faker.lorem.sentence(),
+      content: faker.lorem.paragraphs(),
+      startTime: faker.date.future(),
+      endTime: faker.date.future(),
+      ticleStatus: TicleStatus.OPEN,
+      createdAt: new Date(),
+      profileImageUrl: faker.image.avatar(),
+    });
+    await ticleRepository.save(ticle);
+  }
+
+  console.log('Ticles seeded!');
+};

--- a/apps/api/src/seeds/user.seeder.ts
+++ b/apps/api/src/seeds/user.seeder.ts
@@ -1,0 +1,23 @@
+import { faker } from '@faker-js/faker';
+import { DataSource } from 'typeorm';
+
+import { User } from '../entity/user.entity';
+
+export const seedUsers = async (dataSource: DataSource, count: number) => {
+  const userRepository = dataSource.getRepository(User);
+
+  for (let i = 0; i < count; i++) {
+    const user = userRepository.create({
+      username: faker.internet.userName(),
+      password: faker.internet.password(),
+      nickname: faker.name.firstName(),
+      email: faker.internet.email(),
+      introduce: faker.lorem.sentence(),
+      profileImageUrl: faker.image.avatar(),
+      provider: 'local',
+    });
+    await userRepository.save(user);
+  }
+
+  console.log('Users seeded!');
+};

--- a/apps/api/src/ticle/dto/getTicleListQueryDto.ts
+++ b/apps/api/src/ticle/dto/getTicleListQueryDto.ts
@@ -5,14 +5,6 @@ import { SortType } from '../sortType.enum';
 
 export class GetTicleListQueryDto {
   @ApiProperty({
-    example: 1,
-    description: '페이지 번호',
-    default: 1,
-    required: false,
-  })
-  page?: number = 1;
-
-  @ApiProperty({
     example: 10,
     description: '페이지당 항목 수',
     default: 10,

--- a/apps/api/src/ticle/dto/getTicleListQueryDto.ts
+++ b/apps/api/src/ticle/dto/getTicleListQueryDto.ts
@@ -37,4 +37,11 @@ export class GetTicleListQueryDto {
     required: false,
   })
   sort?: SortType = SortType.NEWEST;
+
+  @ApiProperty({
+    example: '2025-01-14T12:00:00Z',
+    description: 'lastCreatedAt',
+    required: false,
+  })
+  lastSeenCreatedAt?: Date;
 }

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -28,10 +28,10 @@ export class TicleController {
   @Get('list')
   async getTicleList(@Query() query: GetTicleListQueryDto) {
     const parsedQuery = {
-      page: query.page ? Number(query.page) : 1,
       pageSize: query.pageSize ? Number(query.pageSize) : 10,
       isOpen: query.isOpen === undefined ? true : query.isOpen,
       sort: query.sort || SortType.NEWEST,
+      lastSeenCreatedAt: query.lastSeenCreatedAt ? query.lastSeenCreatedAt : null,
     };
     return this.ticleService.getTicleList(parsedQuery);
   }

--- a/apps/api/src/ticle/ticle.service.spec.ts
+++ b/apps/api/src/ticle/ticle.service.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+import { SortType } from './sortType.enum';
+import { TicleService } from './ticle.service'; // 서비스 경로에 맞게 수정
+import { Applicant } from '../entity/applicant.entity';
+import { Summary } from '../entity/summary.entity';
+import { Tag } from '../entity/tag.entity';
+import { Ticle } from '../entity/ticle.entity';
+import { User } from '../entity/user.entity';
+
+describe('TicleService', () => {
+  let service: TicleService;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'mysql',
+          host: 'localhost',
+          port: 3306,
+          username: 'root',
+          password: '123',
+          database: 'ticle_test',
+          entities: [Ticle, User, Applicant, Summary, Tag],
+          synchronize: true, // 테스트 환경에서는 true로 설정
+        }),
+        TypeOrmModule.forFeature([Ticle, User, Applicant, Summary, Tag]),
+      ],
+      providers: [TicleService], // TicleService를 providers에 추가
+    }).compile();
+
+    service = module.get<TicleService>(TicleService);
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy(); // DB 연결 종료
+  });
+
+  it('should measure query performance', async () => {
+    const query = {
+      page: 1,
+      pageSize: 10,
+      isOpen: true,
+      sort: SortType.OLDEST, // 원하는 정렬 타입으로 수정
+    };
+
+    const startTime = Date.now();
+    const result = await service.getTicleList(query);
+    const duration = Date.now() - startTime;
+
+    console.log(`Query executed in: ${duration}ms`);
+
+    expect(result).toHaveProperty('ticles');
+    expect(Number(result.meta.totalItems)).toBeGreaterThan(0); // 적어도 결과가 있어야 함
+  });
+});

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
 import { ErrorMessage, TicleStatus } from '@repo/types';
 
 import { Applicant } from '@/entity/applicant.entity';
@@ -23,7 +23,8 @@ export class TicleService {
     @InjectRepository(Applicant)
     private applicantRepository: Repository<Applicant>,
     @InjectRepository(User)
-    private userRepository: Repository<User>
+    private userRepository: Repository<User>,
+    private readonly entityManager: EntityManager
   ) {}
 
   async createTicle(createTicleDto: CreateTicleDto, userId: number): Promise<Ticle> {
@@ -165,43 +166,62 @@ export class TicleService {
   }
 
   async getTicleList(query: GetTicleListQueryDto) {
-    const { page, pageSize, isOpen, sort } = query;
-    const skip = (page - 1) * pageSize;
-    const queryBuilder = this.ticleRepository
-      .createQueryBuilder('ticle')
-      .select([
-        'ticle.id',
-        'ticle.title',
-        'ticle.startTime',
-        'ticle.endTime',
-        'ticle.speakerName',
-        'ticle.createdAt',
-        'ticle.profileImageUrl',
-      ])
-      .addSelect('GROUP_CONCAT(DISTINCT tags.name)', 'tagNames')
-      .addSelect('COUNT(DISTINCT applicant.id)', 'applicantCount')
-      .addSelect('speaker.profile_image_url')
-      .leftJoin('ticle.tags', 'tags')
-      .leftJoin('ticle.applicants', 'applicant')
-      .leftJoin('ticle.speaker', 'speaker')
-      .where('ticle.ticleStatus IN (:...statuses)', {
-        statuses: isOpen ? [TicleStatus.OPEN, TicleStatus.IN_PROGRESS] : [TicleStatus.CLOSED],
-      })
-      .groupBy('ticle.id');
+    const { pageSize, isOpen, sort, lastSeenCreatedAt } = query;
 
-    switch (sort) {
-      case SortType.OLDEST:
-        queryBuilder.orderBy('ticle.createdAt', 'ASC');
-        break;
-      case SortType.TRENDING:
-        queryBuilder.orderBy('applicantCount', 'DESC').addOrderBy('ticle.createdAt', 'DESC');
-        break;
-      case SortType.NEWEST:
-      default:
-        queryBuilder.orderBy('ticle.createdAt', 'DESC');
+    const isOldest = sort.toLowerCase() === SortType.OLDEST;
+    const orderDirection = isOldest ? 'ASC' : 'DESC';
+    const statuses = isOpen
+      ? `'${TicleStatus.OPEN}', '${TicleStatus.IN_PROGRESS}'`
+      : TicleStatus.CLOSED;
+
+    console.log(lastSeenCreatedAt);
+
+    const currentDate = new Date();
+    let cursor: Date;
+
+    if (!lastSeenCreatedAt) {
+      if (sort.toLowerCase() === SortType.NEWEST) {
+        cursor = currentDate;
+      } else {
+        cursor = new Date('2000-01-01T00:00:00Z');
+      }
+    } else {
+      cursor = new Date(lastSeenCreatedAt);
     }
 
-    const ticles = await queryBuilder.offset(skip).limit(pageSize).getRawMany();
+    cursor.setHours(cursor.getHours() + 9);
+    const formattedCursor = `${cursor.toISOString().slice(0, 19).replace('T', ' ')}.${String(cursor.getMilliseconds()).padStart(3, '0').padEnd(6, '0')}`;
+
+    const naturalQuery = `
+    SELECT 
+        limited_ticles.id AS ticle_id,
+        limited_ticles.speaker_name AS ticle_speaker_name,
+        limited_ticles.title AS ticle_title,
+        limited_ticles.start_time AS ticle_start_time,
+        limited_ticles.end_time AS ticle_end_time,
+        limited_ticles.created_at AS ticle_created_at,
+        limited_ticles.profile_image_url AS ticle_profile_image_url,
+        GROUP_CONCAT(DISTINCT tags.name) AS tagNames,
+        COUNT(DISTINCT applicant.id) AS applicantCount,
+        speaker.profile_image_url AS speaker_profile_image_url
+    FROM (
+        SELECT *
+        FROM ticle
+        WHERE ticle.ticle_status IN (${statuses})
+          AND ticle.created_at ${orderDirection === 'ASC' ? '>' : '<'} ?
+        ORDER BY ticle.created_at ${orderDirection}
+        LIMIT ?
+    ) AS limited_ticles
+    LEFT JOIN ticle_tag ticle_tags ON ticle_tags.ticle_id = limited_ticles.id
+    LEFT JOIN tag tags ON tags.id = ticle_tags.tag_id
+    LEFT JOIN applicant applicant ON applicant.ticle_id = limited_ticles.id
+    LEFT JOIN user speaker ON speaker.id = limited_ticles.speaker_id
+    GROUP BY limited_ticles.id
+    ORDER BY limited_ticles.created_at ${orderDirection};
+  `;
+
+    const result = await this.entityManager.query(naturalQuery, [formattedCursor, pageSize]);
+
     const countQuery = this.ticleRepository
       .createQueryBuilder('ticle')
       .select('COUNT(*) as count')
@@ -210,7 +230,9 @@ export class TicleService {
       });
     const totalTicleCount = await countQuery.getRawOne();
 
-    const formattedTicles = ticles.map((ticle) => ({
+    console.log(result);
+
+    const formattedTicles = result.map((ticle) => ({
       id: ticle.ticle_id,
       title: ticle.ticle_title,
       tags: ticle.tagNames ? ticle.tagNames.split(',') : [],
@@ -227,11 +249,10 @@ export class TicleService {
     return {
       ticles: formattedTicles,
       meta: {
-        page,
         take: pageSize,
         totalItems: totalTicleCount.count,
         totalPages,
-        hasNextPage: page < totalPages,
+        hasNextPage: formattedTicles.length === pageSize,
       },
     };
   }

--- a/apps/media/.Dockerignore
+++ b/apps/media/.Dockerignore
@@ -1,0 +1,2 @@
+# ./apps/web 디렉토리 제외
+apps/web

--- a/apps/media/package.json
+++ b/apps/media/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.700.0",
+    "@faker-js/faker": "^9.3.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
@@ -36,7 +37,8 @@
     "node-fetch": "^2.7.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "typeorm-extension": "^3.6.3"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.700.0
         version: 3.701.0
+      '@faker-js/faker':
+        specifier: ^9.3.0
+        version: 9.3.0
       '@nestjs/common':
         specifier: ^10.4.6
         version: 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -46,16 +49,16 @@ importers:
         version: 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)
       '@nestjs/schedule':
         specifier: ^4.1.1
-        version: 4.1.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))
+        version: 4.1.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)
       '@nestjs/swagger':
         specifier: ^8.0.1
-        version: 8.0.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+        version: 8.0.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/throttler':
         specifier: ^6.2.1
-        version: 6.2.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)
+        version: 6.2.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^10.0.2
-        version: 10.0.2(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+        version: 10.0.2(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
       '@repo/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -107,6 +110,9 @@ importers:
       typeorm:
         specifier: ^0.3.20
         version: 0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3))
+      typeorm-extension:
+        specifier: ^3.6.3
+        version: 3.6.3(typeorm@0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
       winston:
         specifier: ^3.17.0
         version: 3.17.0
@@ -125,7 +131,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.6.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6))
+        version: 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(@nestjs/platform-express@10.4.6)
       '@repo/lint':
         specifier: workspace:*
         version: link:../../packages/eslint
@@ -213,6 +219,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.700.0
         version: 3.700.0
+      '@faker-js/faker':
+        specifier: ^9.3.0
+        version: 9.3.0
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -261,6 +270,9 @@ importers:
       socket.io:
         specifier: ^4.8.1
         version: 4.8.1
+      typeorm-extension:
+        specifier: ^3.6.3
+        version: 3.6.3(typeorm@0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.0.0
@@ -270,7 +282,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.6.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6))
+        version: 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(@nestjs/platform-express@10.4.6)
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
@@ -542,7 +554,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.5.1)
+        version: 8.3.5(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -563,7 +575,7 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.5.1)
+        version: 8.3.5(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -1424,6 +1436,14 @@ packages:
   '@eslint/js@9.14.0':
     resolution: {integrity: sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@faker-js/faker@8.4.1':
+    resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
+
+  '@faker-js/faker@9.3.0':
+    resolution: {integrity: sha512-r0tJ3ZOkMd9xsu3VRfqlFR6cz0V/jFYRswAIpC+m/DIfAUXq7g8N7wTAlhSANySXYGKzGryfDXwtwsY8TxEIDw==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@floating-ui/core@1.6.8':
     resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
@@ -3522,6 +3542,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  destr@2.0.3:
+    resolution: {integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -3579,6 +3602,12 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ebec@1.1.1:
+    resolution: {integrity: sha512-JZ1vcvPQtR+8LGbZmbjG21IxLQq/v47iheJqn2F6yB2CgnGfn8ZVg3myHrf3buIZS8UCwQK0jOSIb3oHX7aH8g==}
+
+  ebec@2.3.0:
+    resolution: {integrity: sha512-bt+0tSL7223VU3PSVi0vtNLZ8pO1AfWolcPPMk2a/a5H+o/ZU9ky0n3A0zhrR4qzJTN61uPsGIO4ShhOukdzxA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -3635,6 +3664,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  envix@1.5.0:
+    resolution: {integrity: sha512-IOxTKT+tffjxgvX2O5nq6enbkv6kBQ/QdMy18bZWo0P0rKPvsRp2/EypIPwTvJfnmk3VdOlq/KcRSZCswefM/w==}
+    engines: {node: '>=18.0.0'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -3977,6 +4010,10 @@ packages:
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
 
   flatbuffers@24.3.25:
     resolution: {integrity: sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ==}
@@ -4637,6 +4674,10 @@ packages:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
     hasBin: true
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -4762,6 +4803,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  locter@2.1.5:
+    resolution: {integrity: sha512-eI57PuVxigQ0GBscGIIFGPB467E5zKODHD3XGuknzLvf7HdnvRw3GdZVGj1J8XKsKOYovZQesX/oOdTwbdjwuQ==}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -5218,6 +5262,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  pascal-case@3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
+
   passport-github2@0.1.12:
     resolution: {integrity: sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==}
     engines: {node: '>= 0.8.0'}
@@ -5506,6 +5553,9 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
+  rapiq@0.9.0:
+    resolution: {integrity: sha512-k4oT4RarFBrlLMJ49xUTeQpa/us0uU4I70D/UEnK3FWQ4GENzei01rEQAmvPKAIzACo4NMW+YcYJ7EVfSa7EFg==}
+
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
@@ -5779,6 +5829,9 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  smob@1.5.0:
+    resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -5840,6 +5893,9 @@ packages:
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
   storybook@8.4.4:
     resolution: {integrity: sha512-xBOq3q/MuUUg3zM0imMMaK5ziKq3TO388jsnaiemJ4Uf0ZGwcHjM8HDBCDt0s5/CfsOQ49zo1ouZ3aNlu0qsUg==}
@@ -6286,6 +6342,13 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typeorm-extension@3.6.3:
+    resolution: {integrity: sha512-AE+8KqBphlBdVz5JS77o6LZzzi+b+YFFt8So4Qu/KRo/iynAwekrx98Oxuu3FAYNm6DUKDcubOBMZsJeiRvHkA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    peerDependencies:
+      typeorm: ~0.3.0
+
   typeorm@0.3.20:
     resolution: {integrity: sha512-sJ0T08dV5eoZroaq9uPKBoNcGslHBR4E4y+EBHs//SiGbblGe7IeduP/IH4ddCcj0qp3PHwDwGnuvqEAnKlq/Q==}
     engines: {node: '>=16.13.0'}
@@ -6628,6 +6691,11 @@ packages:
 
   yaml@2.5.1:
     resolution: {integrity: sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
+  yaml@2.7.0:
+    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -7789,6 +7857,10 @@ snapshots:
 
   '@eslint/js@9.14.0': {}
 
+  '@faker-js/faker@8.4.1': {}
+
+  '@faker-js/faker@9.3.0': {}
+
   '@floating-ui/core@1.6.8':
     dependencies:
       '@floating-ui/utils': 0.2.8
@@ -8221,7 +8293,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nestjs/schedule@4.1.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))':
+  '@nestjs/schedule@4.1.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)':
     dependencies:
       '@nestjs/common': 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -8239,7 +8311,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@8.0.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@8.0.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@nestjs/common': 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -8254,7 +8326,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.1
 
-  '@nestjs/testing@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6))':
+  '@nestjs/testing@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(@nestjs/platform-express@10.4.6)':
     dependencies:
       '@nestjs/common': 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -8262,13 +8334,13 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)
 
-  '@nestjs/throttler@6.2.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)':
+  '@nestjs/throttler@6.2.1(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       reflect-metadata: 0.2.2
 
-  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))':
+  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))':
     dependencies:
       '@nestjs/common': 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(encoding@0.1.12)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -10346,6 +10418,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  destr@2.0.3: {}
+
   destroy@1.2.0: {}
 
   detect-libc@2.0.3: {}
@@ -10387,6 +10461,12 @@ snapshots:
   dotenv@16.4.5: {}
 
   eastasianwidth@0.2.0: {}
+
+  ebec@1.1.1:
+    dependencies:
+      smob: 1.5.0
+
+  ebec@2.3.0: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -10454,6 +10534,10 @@ snapshots:
       tapable: 2.2.1
 
   entities@4.5.0: {}
+
+  envix@1.5.0:
+    dependencies:
+      std-env: 3.8.0
 
   error-ex@1.3.2:
     dependencies:
@@ -10669,7 +10753,7 @@ snapshots:
       debug: 4.3.7(supports-color@9.4.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -10682,7 +10766,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10704,7 +10788,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -11039,6 +11123,8 @@ snapshots:
       flatted: 3.3.1
       keyv: 4.5.4
       rimraf: 3.0.2
+
+  flat@5.0.2: {}
 
   flatbuffers@24.3.25: {}
 
@@ -11889,6 +11975,8 @@ snapshots:
 
   jiti@1.21.6: {}
 
+  jiti@2.4.2: {}
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -12003,6 +12091,15 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  locter@2.1.5:
+    dependencies:
+      destr: 2.0.3
+      ebec: 2.3.0
+      fast-glob: 3.3.2
+      flat: 5.0.2
+      jiti: 2.4.2
+      yaml: 2.7.0
 
   lodash.includes@4.3.0: {}
 
@@ -12457,6 +12554,11 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  pascal-case@3.1.2:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.8.0
+
   passport-github2@0.1.12:
     dependencies:
       passport-oauth2: 1.8.0
@@ -12559,14 +12661,14 @@ snapshots:
       postcss: 8.4.47
       ts-node: 10.9.2(@types/node@22.8.7)(typescript@5.6.3)
 
-  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.5.1):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
       lilconfig: 3.1.2
     optionalDependencies:
-      jiti: 1.21.6
+      jiti: 2.4.2
       postcss: 8.4.47
       tsx: 4.19.2
-      yaml: 2.5.1
+      yaml: 2.7.0
 
   postcss-nested@6.2.0(postcss@8.4.47):
     dependencies:
@@ -12653,6 +12755,11 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  rapiq@0.9.0:
+    dependencies:
+      ebec: 1.1.1
+      smob: 1.5.0
 
   raw-body@2.5.2:
     dependencies:
@@ -12979,6 +13086,8 @@ snapshots:
 
   slash@3.0.0: {}
 
+  smob@1.5.0: {}
+
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -13070,6 +13179,8 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   statuses@2.0.1: {}
+
+  std-env@3.8.0: {}
 
   storybook@8.4.4(prettier@3.3.3):
     dependencies:
@@ -13479,7 +13590,7 @@ snapshots:
 
   tslib@2.8.0: {}
 
-  tsup@8.3.5(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.5.1):
+  tsup@8.3.5(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.24.0)
       cac: 6.7.14
@@ -13489,7 +13600,7 @@ snapshots:
       esbuild: 0.24.0
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.5.1)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.7.0)
       resolve-from: 5.0.0
       rollup: 4.24.4
       source-map: 0.8.0-beta.0
@@ -13594,6 +13705,19 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   typedarray@0.0.6: {}
+
+  typeorm-extension@3.6.3(typeorm@0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3))):
+    dependencies:
+      '@faker-js/faker': 8.4.1
+      consola: 3.2.3
+      envix: 1.5.0
+      locter: 2.1.5
+      pascal-case: 3.1.2
+      rapiq: 0.9.0
+      reflect-metadata: 0.2.2
+      smob: 1.5.0
+      typeorm: 0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3))
+      yargs: 17.7.2
 
   typeorm@0.3.20(mysql2@3.11.3)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)):
     dependencies:
@@ -13946,6 +14070,8 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.5.1: {}
+
+  yaml@2.7.0: {}
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #5 

## 작업 내용

- 데이터 베이스에 더미데이터를 추가하기 위해 `/seeds/*`에 코드를 추가하였습니다. 

- 티클 리스트의 쿼리를 최적화 하였습니다. 
인덱스, 커서 기반 페이지네이션, 서브쿼리를 이용하여 쿼리를 최적화 하였습니다. 



## PR 포인트

쿼리 최적화를 진행하면서 api 형식이 변경되었습니다. 
1. 무한 스크롤에 최적화된 커서 기반 페이지 네이션으로 변경하면서 `page`가 삭제되었습니다.
2. 최적화로 인하여 현재 `trending` 으로 정렬할 수 없습니다. -> 추후 DB구조 변경과 함께 진행해야 합니다. 
3. 커서 기반 페이지네이션이 `created_at`이 기준이므로 커서를 넘겨주어야 합니다. 
따라서 다음 페이지를 찾기 위해서 이전에 조회한 게시글 중 맨 마지막 게시글의 `created_at` 을 다음 조회 요청 시 `lastSeenCreatedAt`변수에 담아 요청해야 합니다. 

 

- 기존 형태
```
page : number - 페이지 번호
pageSize : number - 페이지당 항목 수
isOpen: boolean - 개설 되어있는 티클인지
sort : [newest, oldest, trending] - 최신순, 오래된순, 참가자 많은 순
```

- 변경된 형태 
```
page : number - 페이지 번호
pageSize : number - 페이지당 항목 수
isOpen: boolean - 개설 되어있는 티클인지
sort : [newest, oldest, trending] - 최신순, 오래된순, 참가자 많은 순
lastSeenCreatedAt: 2025-01-14T08:30:25.088Z - 이 시간 이전 또는 이후 티클이 조회됨 (이 조건은 정렬 순서에 따름)
```


예시 : `api/ticle/list?pageSize=10&isOpen=true&sort=NEWEST&lastSeenCreatedAt=2025-01-14T08:30:25.088Z`

## 고민과 학습내용

[블로그](https://velog.io/@pi1199/%EC%BF%BC%EB%A6%AC-%EC%B5%9C%EC%A0%81%ED%99%94#3-%EC%84%9C%EB%B8%8C%EC%BF%BC%EB%A6%AC)

## 스크린샷
