### PR TITLE
[Feat] 모든 참가자의 음성 녹음

### DIFF
--- a/apps/media/src/record/record.service.ts
+++ b/apps/media/src/record/record.service.ts
@@ -29,39 +29,34 @@ export class RecordService {
     }
   }
 
-  async startRecord(roomId: string, socketId: string) {
+  async startRecord(roomId: string) {
     const room = this.roomService.getRoom(roomId);
     if (!room) {
       return;
     }
     const router = room.router;
-    const peer = room.getPeer(socketId);
-    const audioProducer = peer.getAudioProducer();
-    if (!audioProducer) {
-      return;
-    }
+    // 방에있는 모든 audio producer 가져오기
+    const audioProducers = room.getAllAudioProducers();
 
     const port = this.getPort();
-    const recordInfo = this.setRecordInfo(roomId, port, socketId);
+    const recordInfo = this.setRecordInfo(roomId, port);
     const plainTransport = await this.addPlainTransport(recordInfo, router);
     plainTransport.connect({
       ip: '127.0.0.1',
       port,
     });
-    await this.addConsumer(
-      recordInfo,
-      router.rtpCapabilities,
-      audioProducer.id,
-      audioProducer.paused,
-      roomId
-    );
-    if (!audioProducer.paused) {
+
+    // 모든 consumer를 생성하게 하기
+    await this.addConsumer();
+
+    //todo : 방에있는 하나의 음성이라도 있으면 ffmpeg process 생성
+    if (!audioProducers) {
       recordInfo.createFfmpegProcess(roomId);
     }
   }
 
-  private setRecordInfo(roomId: string, port: number, socketId: string) {
-    const recordInfo = new RecordInfo(port, socketId, this.ncpService);
+  private setRecordInfo(roomId: string, port: number) {
+    const recordInfo = new RecordInfo(port, this.ncpService);
     this.recordInfos.set(roomId, recordInfo);
     return recordInfo;
   }
@@ -72,39 +67,14 @@ export class RecordService {
     return plainTransport;
   }
 
-  private async addConsumer(
-    recordInfo: RecordInfo,
-    rtpCapabilities: types.RtpCapabilities,
-    producerId: string,
-    producerPaused: boolean,
-    roomId: string
-  ) {
-    const plainTransport = recordInfo.plainTransport;
-    const consumer = await this.mediasoupService.createRecordConsumer(
-      plainTransport,
-      producerId,
-      rtpCapabilities,
-      producerPaused
-    );
-
-    recordInfo.setRecordConsumer(consumer, roomId);
-    return consumer;
-  }
+  private async addConsumer() {}
 
   pauseRecord(roomId: string) {
-    const recordInfo = this.recordInfos.get(roomId);
-    if (!recordInfo) {
-      return;
-    }
-    recordInfo.pauseRecordProcess();
+    //todo: ffmpeg process pause
   }
 
   resumeRecord(roomId: string) {
-    const recordInfo = this.recordInfos.get(roomId);
-    if (!recordInfo) {
-      return;
-    }
-    recordInfo.resumeRecordProcess();
+    //todo: ffmpeg process resume
   }
 
   stopRecord(roomId: string) {

--- a/apps/media/src/record/record.service.ts
+++ b/apps/media/src/record/record.service.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { WsException } from '@nestjs/websockets';
-import { types } from 'mediasoup';
+import { PlainTransport, Producer, RtpCapabilities } from 'mediasoup/node/lib/types';
 import { ErrorMessage } from '@repo/types';
 
 import { MediasoupService } from '@/mediasoup/mediasoup.service';
@@ -35,19 +35,23 @@ export class RecordService {
       return;
     }
     const router = room.router;
-    // 방에있는 모든 audio producer 가져오기
-    const audioProducers = room.getAllAudioProducers();
-
     const port = this.getPort();
-    const recordInfo = this.setRecordInfo(roomId, port);
-    const plainTransport = await this.addPlainTransport(recordInfo, router);
+
+    const plainTransport = await this.mediasoupService.createPlainTransport(router);
     plainTransport.connect({
       ip: '127.0.0.1',
       port,
     });
 
-    // 모든 consumer를 생성하게 하기
-    await this.addConsumer();
+    const audioProducers = room.getAllAudioProducers();
+
+    const recordInfo = this.createRecordInfo(
+      port,
+      plainTransport,
+      audioProducers,
+      router.rtpCapabilities
+    );
+    this.recordInfos.set(roomId, recordInfo);
 
     //todo : 방에있는 하나의 음성이라도 있으면 ffmpeg process 생성
     if (!audioProducers) {
@@ -55,19 +59,26 @@ export class RecordService {
     }
   }
 
-  private setRecordInfo(roomId: string, port: number) {
+  private createRecordInfo(
+    port: number,
+    plainTransport: PlainTransport,
+    audioProducers: Producer[],
+    rtpCapabilities: RtpCapabilities
+  ) {
     const recordInfo = new RecordInfo(port, this.ncpService);
-    this.recordInfos.set(roomId, recordInfo);
+    recordInfo.setPlainTransport(plainTransport);
+    audioProducers.forEach(async (producer) => {
+      const consumer = await this.mediasoupService.createRecordConsumer(
+        plainTransport,
+        producer.id,
+        rtpCapabilities,
+        producer.paused
+      );
+      recordInfo.addRecordConsumer(consumer);
+    });
+
     return recordInfo;
   }
-
-  private async addPlainTransport(recordInfo: RecordInfo, router: types.Router) {
-    const plainTransport = await this.mediasoupService.createPlainTransport(router);
-    recordInfo.setPlainTransport(plainTransport);
-    return plainTransport;
-  }
-
-  private async addConsumer() {}
 
   pauseRecord(roomId: string) {
     //todo: ffmpeg process pause

--- a/apps/media/src/record/record.service.ts
+++ b/apps/media/src/record/record.service.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { WsException } from '@nestjs/websockets';
-import { PlainTransport, Producer, RtpCapabilities } from 'mediasoup/node/lib/types';
 import { ErrorMessage } from '@repo/types';
 
 import { MediasoupService } from '@/mediasoup/mediasoup.service';
@@ -43,41 +42,33 @@ export class RecordService {
       port,
     });
 
+    const masterPeer = room.getPeer(room.masterSocketId);
+    const masterPeerAudioProducer = masterPeer.getAudioProducer();
     const audioProducers = room.getAllAudioProducers();
 
-    const recordInfo = this.createRecordInfo(
-      port,
-      plainTransport,
-      audioProducers,
-      router.rtpCapabilities
-    );
+    const recordInfo = new RecordInfo(port, this.ncpService, plainTransport);
     this.recordInfos.set(roomId, recordInfo);
 
-    //todo : 방에있는 하나의 음성이라도 있으면 ffmpeg process 생성
-    if (!audioProducers) {
-      recordInfo.createFfmpegProcess(roomId);
-    }
-  }
-
-  private createRecordInfo(
-    port: number,
-    plainTransport: PlainTransport,
-    audioProducers: Producer[],
-    rtpCapabilities: RtpCapabilities
-  ) {
-    const recordInfo = new RecordInfo(port, this.ncpService);
-    recordInfo.setPlainTransport(plainTransport);
     audioProducers.forEach(async (producer) => {
       const consumer = await this.mediasoupService.createRecordConsumer(
         plainTransport,
         producer.id,
-        rtpCapabilities,
+        router.rtpCapabilities,
         producer.paused
       );
+      if (producer.id === masterPeerAudioProducer.id) {
+        recordInfo.setMasterConsumerRtpParameters(consumer.rtpParameters);
+        if (producer.paused) {
+          consumer.once('producerresume', () => {
+            recordInfo.createFfmpegProcess(roomId);
+            console.log('master consumer resume');
+          });
+          return;
+        }
+        recordInfo.createFfmpegProcess(roomId);
+      }
       recordInfo.addRecordConsumer(consumer);
     });
-
-    return recordInfo;
   }
 
   stopRecord(roomId: string) {
@@ -117,8 +108,5 @@ export class RecordService {
   }
 }
 
-//todo : 방장 마이크 키기 전까지 ffmepg실행안되게하기
-//todo : 방장 마이크 키면 ffmpeg실행
 //todo : 새로운 사용자 입장 시 consumer 추가
 //todo : 사용자 나가기 시 consumer 삭제
-//todo :

--- a/apps/media/src/record/record.service.ts
+++ b/apps/media/src/record/record.service.ts
@@ -46,29 +46,49 @@ export class RecordService {
     const masterPeerAudioProducer = masterPeer.getAudioProducer();
     const audioProducers = room.getAllAudioProducers();
 
-    const recordInfo = new RecordInfo(port, this.ncpService, plainTransport);
+    const recordInfo = new RecordInfo(
+      port,
+      this.ncpService,
+      plainTransport,
+      router.rtpCapabilities
+    );
     this.recordInfos.set(roomId, recordInfo);
 
     audioProducers.forEach(async (producer) => {
       const consumer = await this.mediasoupService.createRecordConsumer(
         plainTransport,
         producer.id,
-        router.rtpCapabilities,
+        recordInfo.rtpCapabilities,
         producer.paused
       );
+      recordInfo.addRecordConsumer(consumer);
+
       if (producer.id === masterPeerAudioProducer.id) {
         recordInfo.setMasterConsumerRtpParameters(consumer.rtpParameters);
         if (producer.paused) {
           consumer.once('producerresume', () => {
             recordInfo.createFfmpegProcess(roomId);
-            console.log('master consumer resume');
           });
           return;
         }
         recordInfo.createFfmpegProcess(roomId);
       }
-      recordInfo.addRecordConsumer(consumer);
     });
+  }
+
+  async addNewRecordConsumer(roomId: string, producerId: string, producerPaused: boolean) {
+    const recordInfo = this.recordInfos.get(roomId);
+    if (!recordInfo) {
+      return;
+    }
+    const plainTransport = recordInfo.plainTransport;
+    const consumer = await this.mediasoupService.createRecordConsumer(
+      plainTransport,
+      producerId,
+      recordInfo.rtpCapabilities,
+      producerPaused
+    );
+    recordInfo.addRecordConsumer(consumer);
   }
 
   stopRecord(roomId: string) {
@@ -107,6 +127,3 @@ export class RecordService {
     return this.recordInfos.has(roomId);
   }
 }
-
-//todo : 새로운 사용자 입장 시 consumer 추가
-//todo : 사용자 나가기 시 consumer 삭제

--- a/apps/media/src/record/record.service.ts
+++ b/apps/media/src/record/record.service.ts
@@ -80,14 +80,6 @@ export class RecordService {
     return recordInfo;
   }
 
-  pauseRecord(roomId: string) {
-    //todo: ffmpeg process pause
-  }
-
-  resumeRecord(roomId: string) {
-    //todo: ffmpeg process resume
-  }
-
   stopRecord(roomId: string) {
     const recordInfo = this.recordInfos.get(roomId);
     if (!recordInfo) {
@@ -124,3 +116,9 @@ export class RecordService {
     return this.recordInfos.has(roomId);
   }
 }
+
+//todo : 방장 마이크 키기 전까지 ffmepg실행안되게하기
+//todo : 방장 마이크 키면 ffmpeg실행
+//todo : 새로운 사용자 입장 시 consumer 추가
+//todo : 사용자 나가기 시 consumer 삭제
+//todo :

--- a/apps/media/src/record/recordInfo.ts
+++ b/apps/media/src/record/recordInfo.ts
@@ -8,33 +8,29 @@ import { NcpService } from '@/ncp/ncp.service';
 export class RecordInfo {
   plainTransport: PlainTransport;
   recordConsumers: Map<string, Consumer>;
+  masterConsumerRtpParameters: RtpParameters;
+  port: number;
 
   ncpService: NcpService;
 
-  port: number;
-
   ffmpegProcess: FfmpegCommand;
 
-  constructor(port: number, ncpService: NcpService) {
+  constructor(port: number, ncpService: NcpService, plainTransport: PlainTransport) {
     this.port = port;
     this.ncpService = ncpService;
     this.recordConsumers = new Map();
-  }
-
-  setPlainTransport(plainTransport: PlainTransport) {
     this.plainTransport = plainTransport;
   }
 
   addRecordConsumer(recordConsumer: Consumer) {
-    this.recordConsumers.set(recordConsumer.id, recordConsumer);
-    recordConsumer.once('producerresume', () => {
-      // todo : 실행중인지 판단하는 코드 추가한 뒤 전체에서 한번만 실행하게하기
-      // if (!this.ffmpegProcess) {
-      //   this.createFfmpegProcess(roomId);
-      // }
+    recordConsumer.on('producerclose', () => {
+      this.recordConsumers.delete(recordConsumer.id);
     });
+    this.recordConsumers.set(recordConsumer.id, recordConsumer);
   }
-
+  setMasterConsumerRtpParameters(rtpParameters: RtpParameters) {
+    this.masterConsumerRtpParameters = rtpParameters;
+  }
   clearStream() {
     if (this.recordConsumers) {
       this.recordConsumers.forEach((consumer) => {
@@ -54,8 +50,7 @@ export class RecordInfo {
     }
 
     // todo : 대표적인 음성 rtpparameter를 가져옴
-    const rtpParameter = this.recordConsumer.rtpParameters;
-    const sdpString = this.createSdpText(this.port, rtpParameter);
+    const sdpString = this.createSdpText();
     const sdpFilePath = `./record/${roomId}_${Date.now()}.sdp`;
     writeFileSync(sdpFilePath, sdpString);
 
@@ -86,15 +81,15 @@ export class RecordInfo {
     this.ffmpegProcess = ffmpegCommand;
   }
 
-  private createSdpText = (port: number, rtpParameters: RtpParameters) => {
-    const { codecs } = rtpParameters;
+  private createSdpText = () => {
+    const { codecs } = this.masterConsumerRtpParameters;
     const payloadType = codecs[0].payloadType;
     return `v=0
 o=- 0 0 IN IP4 127.0.0.1
 s=FFmpeg
 c=IN IP4 127.0.0.1
 t=0 0
-m=audio ${port} RTP/AVP ${payloadType}
+m=audio ${this.port} RTP/AVP ${payloadType}
 a=rtpmap:${payloadType} opus/48000/2
 a=fmtp:${payloadType} minptime=10;useinbandfec=1
 a=sendrecv

--- a/apps/media/src/record/recordInfo.ts
+++ b/apps/media/src/record/recordInfo.ts
@@ -1,13 +1,13 @@
 import { unlinkSync, writeFileSync } from 'fs';
 
 import ffmpeg, { FfmpegCommand } from 'fluent-ffmpeg';
-import { types } from 'mediasoup';
+import { Consumer, PlainTransport, RtpParameters } from 'mediasoup/node/lib/types';
 
 import { NcpService } from '@/ncp/ncp.service';
 
 export class RecordInfo {
-  plainTransport: types.PlainTransport;
-  recordConsumers: Map<string, types.Consumer>;
+  plainTransport: PlainTransport;
+  recordConsumers: Map<string, Consumer>;
 
   ncpService: NcpService;
 
@@ -18,15 +18,16 @@ export class RecordInfo {
   constructor(port: number, ncpService: NcpService) {
     this.port = port;
     this.ncpService = ncpService;
+    this.recordConsumers = new Map();
   }
 
-  setPlainTransport(plainTransport: types.PlainTransport) {
+  setPlainTransport(plainTransport: PlainTransport) {
     this.plainTransport = plainTransport;
   }
 
-  setRecordConsumer(recordConsumer: types.Consumer, roomId: string) {
+  addRecordConsumer(recordConsumer: Consumer) {
     this.recordConsumers.set(recordConsumer.id, recordConsumer);
-    recordConsumer.on('producerresume', () => {
+    recordConsumer.once('producerresume', () => {
       // todo : 실행중인지 판단하는 코드 추가한 뒤 전체에서 한번만 실행하게하기
       // if (!this.ffmpegProcess) {
       //   this.createFfmpegProcess(roomId);
@@ -85,7 +86,7 @@ export class RecordInfo {
     this.ffmpegProcess = ffmpegCommand;
   }
 
-  private createSdpText = (port: number, rtpParameters: types.RtpParameters) => {
+  private createSdpText = (port: number, rtpParameters: RtpParameters) => {
     const { codecs } = rtpParameters;
     const payloadType = codecs[0].payloadType;
     return `v=0

--- a/apps/media/src/record/recordInfo.ts
+++ b/apps/media/src/record/recordInfo.ts
@@ -1,7 +1,7 @@
 import { unlinkSync, writeFileSync } from 'fs';
 
 import ffmpeg, { FfmpegCommand } from 'fluent-ffmpeg';
-import { Consumer, PlainTransport, RtpParameters } from 'mediasoup/node/lib/types';
+import { Consumer, PlainTransport, RtpCapabilities, RtpParameters } from 'mediasoup/node/lib/types';
 
 import { NcpService } from '@/ncp/ncp.service';
 
@@ -9,17 +9,24 @@ export class RecordInfo {
   plainTransport: PlainTransport;
   recordConsumers: Map<string, Consumer>;
   masterConsumerRtpParameters: RtpParameters;
+  rtpCapabilities: RtpCapabilities;
   port: number;
 
   ncpService: NcpService;
 
   ffmpegProcess: FfmpegCommand;
 
-  constructor(port: number, ncpService: NcpService, plainTransport: PlainTransport) {
+  constructor(
+    port: number,
+    ncpService: NcpService,
+    plainTransport: PlainTransport,
+    rtpCapabilities: RtpCapabilities
+  ) {
     this.port = port;
     this.ncpService = ncpService;
     this.recordConsumers = new Map();
     this.plainTransport = plainTransport;
+    this.rtpCapabilities = rtpCapabilities;
   }
 
   addRecordConsumer(recordConsumer: Consumer) {
@@ -49,7 +56,6 @@ export class RecordInfo {
       return;
     }
 
-    // todo : 대표적인 음성 rtpparameter를 가져옴
     const sdpString = this.createSdpText();
     const sdpFilePath = `./record/${roomId}_${Date.now()}.sdp`;
     writeFileSync(sdpFilePath, sdpString);

--- a/apps/media/src/record/recordInfo.ts
+++ b/apps/media/src/record/recordInfo.ts
@@ -6,9 +6,8 @@ import { types } from 'mediasoup';
 import { NcpService } from '@/ncp/ncp.service';
 
 export class RecordInfo {
-  socketId: string;
   plainTransport: types.PlainTransport;
-  recordConsumer: types.Consumer;
+  recordConsumers: Map<string, types.Consumer>;
 
   ncpService: NcpService;
 
@@ -16,9 +15,8 @@ export class RecordInfo {
 
   ffmpegProcess: FfmpegCommand;
 
-  constructor(port: number, socketId: string, ncpService: NcpService) {
+  constructor(port: number, ncpService: NcpService) {
     this.port = port;
-    this.socketId = socketId;
     this.ncpService = ncpService;
   }
 
@@ -27,26 +25,21 @@ export class RecordInfo {
   }
 
   setRecordConsumer(recordConsumer: types.Consumer, roomId: string) {
-    this.recordConsumer = recordConsumer;
-    this.recordConsumer.on('producerresume', () => {
-      if (!this.ffmpegProcess) {
-        this.createFfmpegProcess(roomId);
-      }
+    this.recordConsumers.set(recordConsumer.id, recordConsumer);
+    recordConsumer.on('producerresume', () => {
+      // todo : 실행중인지 판단하는 코드 추가한 뒤 전체에서 한번만 실행하게하기
+      // if (!this.ffmpegProcess) {
+      //   this.createFfmpegProcess(roomId);
+      // }
     });
   }
 
-  pauseRecordProcess() {
-    this.recordConsumer.pause();
-  }
-
-  resumeRecordProcess() {
-    this.recordConsumer.resume();
-  }
-
   clearStream() {
-    if (this.recordConsumer) {
-      this.recordConsumer.close();
-      this.recordConsumer = null;
+    if (this.recordConsumers) {
+      this.recordConsumers.forEach((consumer) => {
+        consumer.close();
+      });
+      this.recordConsumers.clear();
     }
     if (this.plainTransport) {
       this.plainTransport.close();
@@ -59,6 +52,7 @@ export class RecordInfo {
       return;
     }
 
+    // todo : 대표적인 음성 rtpparameter를 가져옴
     const rtpParameter = this.recordConsumer.rtpParameters;
     const sdpString = this.createSdpText(this.port, rtpParameter);
     const sdpFilePath = `./record/${roomId}_${Date.now()}.sdp`;

--- a/apps/media/src/room/room.ts
+++ b/apps/media/src/room/room.ts
@@ -1,5 +1,5 @@
 import { WsException } from '@nestjs/websockets';
-import { Router } from 'mediasoup/node/lib/RouterTypes';
+import { Producer, Router } from 'mediasoup/node/lib/types';
 import { ErrorMessage } from '@repo/types';
 
 import { Peer } from './peer';
@@ -55,7 +55,14 @@ export class Room {
     return false;
   }
 
-  getAllAudioProducers() {}
+  getAllAudioProducers(): Producer[] {
+    const audioProducers = [];
+    this.peers.forEach((peer) => {
+      const producer = peer.getAudioProducer();
+      if (producer) audioProducers.push(producer);
+    });
+    return audioProducers;
+  }
 
   close() {
     this.peers.forEach((peer) => peer.close());

--- a/apps/media/src/room/room.ts
+++ b/apps/media/src/room/room.ts
@@ -55,6 +55,8 @@ export class Room {
     return false;
   }
 
+  getAllAudioProducers() {}
+
   close() {
     this.peers.forEach((peer) => peer.close());
     this.peers.clear();

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -89,9 +89,10 @@ export class SignalingGateway implements OnGatewayDisconnect {
       appData,
       paused: producerData.paused,
     };
-
+    if (kind === 'audio') {
+      this.recordService.addNewRecordConsumer(roomId, producerData.producerId, producerData.paused);
+    }
     client.to(roomId).emit(SOCKET_EVENTS.newProducer, createProducerRes);
-
     return createProducerRes;
   }
 

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -209,15 +209,6 @@ export class SignalingGateway implements OnGatewayDisconnect {
     this.recordService.stopRecord(roomId);
   }
 
-  @SubscribeMessage(SOCKET_EVENTS.pauseRecord)
-  pauseRecord(@MessageBody('roomId') roomId: string) {
-    this.recordService.pauseRecord(roomId);
-  }
-
-  @SubscribeMessage(SOCKET_EVENTS.resumeRecord)
-  resumeRecord(@MessageBody('roomId') roomId: string) {
-    this.recordService.resumeRecord(roomId);
-  }
   @SubscribeMessage(SOCKET_EVENTS.getIsRecording)
   getIsRecording(@MessageBody('roomId') roomId: string) {
     const isRecording = this.recordService.getIsRecording(roomId);

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -200,8 +200,8 @@ export class SignalingGateway implements OnGatewayDisconnect {
   }
 
   @SubscribeMessage(SOCKET_EVENTS.startRecord)
-  async startRecord(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
-    await this.recordService.startRecord(roomId, client.id);
+  async startRecord(@MessageBody('roomId') roomId: string) {
+    await this.recordService.startRecord(roomId);
   }
 
   @SubscribeMessage(SOCKET_EVENTS.stopRecord)


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #7 

## 작업 내용
- 녹음 시작 클릭 시 현재 방에 존재하는 모든 producer에 대한 consumer를 생성하여 음성 받아옴
- 녹음 중일 떄 참가자 입장/퇴장 시 해당 참가자의 producer에 대한 consumer 생성/제거

## PR 포인트

## 고민과 학습내용
- 녹음을 위한 plain transport를 생성 후 녹음하고자 하는 소스의 producer 에 대한 consumer들을 생성하였습니다.
- 이전 작업에서는 녹음하려는 소스 하나 당 하나의 plain transport와 ffmpeg 프로세스가 필요하다 판단하여 음성 패킷을 합치려는 시도를 했었습니다.
- 다시 생각해보니 transport는 통로일 뿐이라는 것을 까먹고 있었습니다. 실질적인 패킷 전송, 수신은 producer,consumer가 담당합니다.
- 따라서 녹음을 위한 transport는 티클 방 당 하나 생성되고, 녹음을 하고자 하는 producer에 대한 consumer들을 생성해주는 방식으로 구현하였습니다.

## 스크린샷
